### PR TITLE
update workflow copy to include closing prayer

### DIFF
--- a/.github/workflows/support-03-sermon-audio-process.yml
+++ b/.github/workflows/support-03-sermon-audio-process.yml
@@ -44,6 +44,7 @@ jobs:
             ### Checklist
 
             - [ ] Process and scrub the sermon audio
+              - [ ] Ensure that the file includes the closing prayer
             - [ ] Upload processed audiofile to S3 bucket
             - [ ] Update the "Sermon" document in Sanity to include the correct S3 path and deploy
             - [ ] When complete, shift card to "Ready to Review" and tag ${reviewers}

--- a/.github/workflows/support-04-sermon-video-process.yml
+++ b/.github/workflows/support-04-sermon-video-process.yml
@@ -45,6 +45,7 @@ jobs:
             ### Checklist
 
             - [ ] Process and review the sermon video
+              - [ ] Ensure that the file includes the closing prayer
             - [ ] Create Canva card with "SERMON Card" template
             - [ ] Upload video into YouTube & attach canva card
             - [ ] Update the "Sermon" document in Sanity to include the correct YouTube ID and deploy


### PR DESCRIPTION
this updates the issue body templates of the "sermon audio" and "sermon video" to include extra checkboxes for adding in the closing prayers

eg:
<img width="400" alt="image" src="https://github.com/metrophilly/docs.metrophilly.org/assets/8061917/843815da-70c1-4823-9f89-1730205bf1cc">

^ (this was manually added by ellis tho — this PR adds it directly in so no updates need to be made)